### PR TITLE
Adding _.getQuery() functionality back into master

### DIFF
--- a/bin/undermore.js
+++ b/bin/undermore.js
@@ -1,4 +1,4 @@
-/*! undermore - v0.2.0 - 2014-04-25
+/*! undermore - v0.2.0 - 2014-06-25
 * https://github.com/atomantic/undermore
 * Copyright (c) 2014 Adam Eivy (@antic); Licensed MIT */
  /*global exports,Buffer,atob,btoa,escape,unescape*/
@@ -192,6 +192,49 @@ fnMore: function(originalFn, moreFn, scope) {
         moreFn();
     };
 }, 
+ /**
+ * Get the requested key from the query string.
+ * If no key is provided, return a map of all
+ * query string values.
+ *
+ * @param {string} key The key to retrieve from the query string
+ * @param {*} defaultValue The default value to return if key does not exist
+ * @example:
+ *  // URL: http://foo.com?a=b&foo=bar
+ *  _.getQuery() === { a: 'b', foo: 'bar' }
+ *  _.getQuery('a') === 'b'
+ *  _.getQuery('b') === undefined
+ *  _.getQuery('c', 'd') === 'd'
+ *  _.getQuery('a', 'baz') === 'b'
+ */
+getQuery: (function () {
+    var o;
+    var parseIt = function () {
+        o = {};
+        var query = (function (query) {
+            if (query && query.length > 0) {
+                return query.replace(/^\?/, '').split('&');
+            }
+            return [];
+        })(window.location.search);
+
+        _.map(query, function (item) {
+            var param = item.split('=');
+            if (param.length === 2) {
+                o[param[0]] = param[1];
+            }
+        });
+    };
+
+    return function (key, defaultValue) {
+        if (typeof o === 'undefined') {
+            parseIt();
+        }
+
+        return typeof key === 'undefined' ? o : (typeof o[key] === 'undefined' ? defaultValue : o[key]);
+    };
+})()
+, 
  /**
  * Get the english ordinal suffix for any number
  *

--- a/dist/css/docs.css
+++ b/dist/css/docs.css
@@ -19,9 +19,14 @@ body {
 
 .fork {
   position: absolute; 
-  top: 0; 
+  top: 30px; 
   right: 0; 
   border: 0;
+}
+@media (max-width: 480px){
+  .fork {
+    top: 50px; 
+  }
 }
 
 /* Tweak navbar brand link to be super sleek

--- a/dist/undermore.js
+++ b/dist/undermore.js
@@ -1,4 +1,4 @@
-/*! undermore - v0.2.0 - 2014-04-25
+/*! undermore - v0.2.0 - 2014-06-25
 * https://github.com/atomantic/undermore
 * Copyright (c) 2014 Adam Eivy (@antic); Licensed MIT */
  /*global exports,Buffer,atob,btoa,escape,unescape*/
@@ -192,6 +192,49 @@ fnMore: function(originalFn, moreFn, scope) {
         moreFn();
     };
 }, 
+ /**
+ * Get the requested key from the query string.
+ * If no key is provided, return a map of all
+ * query string values.
+ *
+ * @param {string} key The key to retrieve from the query string
+ * @param {*} defaultValue The default value to return if key does not exist
+ * @example:
+ *  // URL: http://foo.com?a=b&foo=bar
+ *  _.getQuery() === { a: 'b', foo: 'bar' }
+ *  _.getQuery('a') === 'b'
+ *  _.getQuery('b') === undefined
+ *  _.getQuery('c', 'd') === 'd'
+ *  _.getQuery('a', 'baz') === 'b'
+ */
+getQuery: (function () {
+    var o;
+    var parseIt = function () {
+        o = {};
+        var query = (function (query) {
+            if (query && query.length > 0) {
+                return query.replace(/^\?/, '').split('&');
+            }
+            return [];
+        })(window.location.search);
+
+        _.map(query, function (item) {
+            var param = item.split('=');
+            if (param.length === 2) {
+                o[param[0]] = param[1];
+            }
+        });
+    };
+
+    return function (key, defaultValue) {
+        if (typeof o === 'undefined') {
+            parseIt();
+        }
+
+        return typeof key === 'undefined' ? o : (typeof o[key] === 'undefined' ? defaultValue : o[key]);
+    };
+})()
+, 
  /**
  * Get the english ordinal suffix for any number
  *

--- a/src/_.build.js
+++ b/src/_.build.js
@@ -190,6 +190,49 @@ fnMore: function(originalFn, moreFn, scope) {
     };
 }, 
  /**
+ * Get the requested key from the query string.
+ * If no key is provided, return a map of all
+ * query string values.
+ *
+ * @param {string} key The key to retrieve from the query string
+ * @param {*} defaultValue The default value to return if key does not exist
+ * @example:
+ *  // URL: http://foo.com?a=b&foo=bar
+ *  _.getQuery() === { a: 'b', foo: 'bar' }
+ *  _.getQuery('a') === 'b'
+ *  _.getQuery('b') === undefined
+ *  _.getQuery('c', 'd') === 'd'
+ *  _.getQuery('a', 'baz') === 'b'
+ */
+getQuery: (function () {
+    var o;
+    var parseIt = function () {
+        o = {};
+        var query = (function (query) {
+            if (query && query.length > 0) {
+                return query.replace(/^\?/, '').split('&');
+            }
+            return [];
+        })(window.location.search);
+
+        _.map(query, function (item) {
+            var param = item.split('=');
+            if (param.length === 2) {
+                o[param[0]] = param[1];
+            }
+        });
+    };
+
+    return function (key, defaultValue) {
+        if (typeof o === 'undefined') {
+            parseIt();
+        }
+
+        return typeof key === 'undefined' ? o : (typeof o[key] === 'undefined' ? defaultValue : o[key]);
+    };
+})()
+, 
+ /**
  * Get the english ordinal suffix for any number
  *
  * @param {number} n number The number to evaluate

--- a/src/_source/_.getQuery.js
+++ b/src/_source/_.getQuery.js
@@ -1,0 +1,42 @@
+/**
+ * Get the requested key from the query string.
+ * If no key is provided, return a map of all
+ * query string values.
+ *
+ * @param {string} key The key to retrieve from the query string
+ * @param {*} defaultValue The default value to return if key does not exist
+ * @example:
+ *  // URL: http://foo.com?a=b&foo=bar
+ *  _.getQuery() === { a: 'b', foo: 'bar' }
+ *  _.getQuery('a') === 'b'
+ *  _.getQuery('b') === undefined
+ *  _.getQuery('c', 'd') === 'd'
+ *  _.getQuery('a', 'baz') === 'b'
+ */
+getQuery: (function () {
+    var o;
+    var parseIt = function () {
+        o = {};
+        var query = (function (query) {
+            if (query && query.length > 0) {
+                return query.replace(/^\?/, '').split('&');
+            }
+            return [];
+        })(window.location.search);
+
+        _.map(query, function (item) {
+            var param = item.split('=');
+            if (param.length === 2) {
+                o[param[0]] = param[1];
+            }
+        });
+    };
+
+    return function (key, defaultValue) {
+        if (typeof o === 'undefined') {
+            parseIt();
+        }
+
+        return typeof key === 'undefined' ? o : (typeof o[key] === 'undefined' ? defaultValue : o[key]);
+    };
+})()

--- a/test/undermore_test.js
+++ b/test/undermore_test.js
@@ -1,8 +1,14 @@
 /*jslint jquery:true,browser:true */
 /*global _,QUnit,test,module,deepEqual,equal,define,ok,notEqual*/
+
+// In order to test _.getQuery(), we need to assure we have a query string
+var targetQuery = '?a=b&foo=bar';
+if (window.location.search !== targetQuery) {
+    window.location.search = targetQuery;
+}
+
 define(['../src/_.build.js', '../src/safe.js'], function() {
     'use strict';
-
     /*
     ======== A Handy Little QUnit Reference ========
     http://api.qunitjs.com/
@@ -73,7 +79,6 @@ define(['../src/_.build.js', '../src/safe.js'], function() {
 
 
     test('utf8', function() {
-
         var data = [
             // 1-byte
             {
@@ -300,4 +305,21 @@ define(['../src/_.build.js', '../src/safe.js'], function() {
 
     });
 
+    test('getQuery', function () {
+        var data = { a: 'b', foo: 'bar' };
+        var params = _.getQuery();
+
+        for (var k in data) {
+            if (data.hasOwnProperty(k)) {
+                ok(params.hasOwnProperty(k), 'Parameter "' + k + '" should exist in query string');
+                equal(params[k], data[k], 'Parameter "' + k + '" should equal "' + data[k] + '"');
+            }
+        }
+
+        // These tests are directly out of the example code from the definition file
+        equal(_.getQuery('a'), 'b', 'Query parameter "a" should be "b"');
+        equal(_.getQuery('b'), undefined, 'Query parameter "b" should be undefined');
+        equal(_.getQuery('c', 'd'), 'd', 'Undefined query parameter should result in default value, if present');
+        equal(_.getQuery('a', 'baz'), 'b', 'Default value should not override existing query string value');
+    });
 });


### PR DESCRIPTION
This commit adds query string parsing capabilities to undermore along with corresponding unit testing. This plugin memoizes the query string parser on the first call to speed up any subsequent readings:

``` javascript
// URL: http://foo.com?a=b&foo=bar
_.getQuery() === { a: 'b', foo: 'bar' };
_.getQuery('a') === 'b';
_.getQuery('bin', 'baz') === 'baz';
_.getQuery('z') === undefined;
```
