### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,25 +28,25 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "lodash": ">=2.4.1"
+    "lodash": "3.10.1"
   },
   "devDependencies": {
-    "event-stream": "^3.1.7",
-    "gulp": "^3.8.8",
-    "gulp-concat": "^2.4.1",
-    "gulp-concat-util": "^0.4.0",
-    "gulp-insert": "^0.4.0",
-    "gulp-jsdoc": "^0.1.4",
-    "gulp-jshint": "^1.8.4",
-    "gulp-qunit": "^0.3.3",
-    "gulp-rename": "^1.2.0",
-    "gulp-rimraf": "^0.1.0",
-    "gulp-sourcemaps": "^1.1.5",
-    "gulp-uglify": "^1.0.1",
-    "gulp-util": "^3.0.1",
-    "gulp-watch": "^1.0.5",
-    "jshint-stylish": "^0.4.0",
-    "yargs": "^1.3.1"
+    "event-stream": "3.3.1",
+    "gulp": "3.9.0",
+    "gulp-concat": "2.6.0",
+    "gulp-concat-util": "0.4.0",
+    "gulp-insert": "0.4.0",
+    "gulp-jsdoc": "0.1.4",
+    "gulp-jshint": "1.11.2",
+    "gulp-qunit": "0.3.3",
+    "gulp-rename": "1.2.2",
+    "gulp-rimraf": "0.1.1",
+    "gulp-sourcemaps": "1.6.0",
+    "gulp-uglify": "1.4.1",
+    "gulp-util": "3.0.6",
+    "gulp-watch": "1.2.1",
+    "jshint-stylish": "0.4.0",
+    "yargs": "1.3.3"
   },
   "keywords": [
     "underscore",


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:

- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>